### PR TITLE
add service maturity level attributes to catalog file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,6 +5,7 @@ metadata:
   description: Manipulate CODEOWNERS file
   annotations:
     github.com/project-slug: loadsmart/meta-codeowners
+    opslevel.com/tier: tier_4
   tags:
     - javascript
 spec:


### PR DESCRIPTION

### Context
The purpose of this pull request is to ensure the repository has basic attributes for service maturity level in backstage catalog, in line with the service maturity level initiative led by the Developer Productivity Squad.
